### PR TITLE
Updates to README links

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -5,21 +5,24 @@
 
 <p align="center">
 <a href="https://chat.lfx.linuxfoundation.org/#/welcome" alt="element"><img src="https://img.shields.io/badge/element-@openbao--element-green.svg" alt="element"></img></a>
-<a href="https://www.lfedge.org/projects/openbao/" alt="Project page"><img src="https://img.shields.io/badge/projectpage-@openbao--projectpage-orange.svg" alt="Project Page"></img></a>
-<a href="https://wiki.lfedge.org/display/OH/Hashicorp+Vault+Replacement+Feature+Design+Candidate" alt="Wiki"><img src="https://img.shields.io/badge/wiki-@lf_edge--wiki-9cf.svg" alt="wiki"></img></a>
+<a href="https://openbao.org" alt="Project website"><img src="https://img.shields.io/badge/website-openbao.org-blue.svg" alt="Project website"></img></a>
+<a href="https://www.lfedge.org/projects/openbao/" alt="LF Edge Project Page"><img src="https://img.shields.io/badge/projectpage-openbao_@_LF_Edge-orange.svg" alt="LF Edge Project Page"></img></a>
+<a href="https://lf-edge.atlassian.net/wiki/spaces/OP/overview" alt="Wiki"><img src="https://img.shields.io/badge/wiki-@lf_edge--wiki-9cf.svg" alt="wiki"></img></a>
 
 </p>
 
-[OpenBao](https://www.lfedge.org/projects/openbao/) is an identity-based secrets and encryption management system
+[OpenBao](https://openbao.org) is an identity-based secrets and encryption management system with open governance under [Linux Foundation Edge](https://www.lfedge.org/projects/openbao/).
 
 ## Contact
+
 For reporting bugs, requesting features, and discussing changes, developers should use Github issues and discussions on these repositories. To connect with the community and learn more about the software solution, new users should bookmark or visit the [OpenBao web site](https://www.lfedge.org/projects/openbao/).
 
 You can reach out to us through the following channels as well:
 
 - [Mailing List](https://lists.lfedge.org/g/openbao)
 - [TSC Mailing List](https://lists.lfedge.org/g/openbao-tsc)
-- [Chat Server](https://chat.lfx.linuxfoundation.org/ )
+- [Chat Server](https://chat.lfx.linuxfoundation.org/)
+- [GitHub Discussions](https://github.com/orgs/openbao/discussions)
 
 ### Community driven development
 
@@ -27,12 +30,12 @@ We love ❤ open source and building our project in the open.
 
 - At [LF Edge](https://www.lfedge.org/), the umbrella group within the Linux Foundation, OpenBao is a Stage One: At-Large project.
 - Join us so we can make OpenBao more robust and more inclusive.
-- Please read our [contribution guidelines](https://github.com/openbao/openbao/blob/main/CONTRIBUTING.md) for details of how you can get involved, and [Code of Conduct](https://lfprojects.org/policies/code-of-conduct/) for information about how to participate.
+- Please read our [contribution guidelines](https://github.com/openbao/openbao/blob/main/CONTRIBUTING.md) for details of how you can get involved and [Code of Conduct](https://lfprojects.org/policies/code-of-conduct/) for information about how to participate.
 
 ### Appendix
 
 - [Documentation Site](https://openbao.org/)
-- [Getting Involved with LF Edge](https://www.lfedge.org/wp-content/uploads/2022/01/Getting-Involved-with-LF-Edge_Jan2022.pdf)
+- [Contributing](https://github.com/openbao/openbao/blob/main/CONTRIBUTING.md)
 - [Mentorship Opportunities](https://wiki.lfedge.org/display/OH/Mentorship+Programs)
 - [Code of Conduct](https://lfprojects.org/policies/code-of-conduct/)
 - [Anti-trust Policy](https://lfprojects.org/policies/antitrust-policy/)


### PR DESCRIPTION
This updates various links to point to our website and not to the LF Edge project page and adjusts some wording. 

The LF Edge getting involved link appears to 404, so I've replaced it with a link to our contributing document. 