### PR TITLE
Link to security policy on organization profile page

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,7 @@
 # Security Policy
 
 ## Reporting a vulnerability
+
 We take OpenBao's security and our users' trust very seriously. If you believe you have found a security issue in OpenBao, please responsibly disclose by contacting us at [openbao-security@lists.lfedge.org](mailto:openbao-security@lists.lfedge.org).
 
-## CVE History
+## CVE history

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,3 +5,5 @@
 We take OpenBao's security and our users' trust very seriously. If you believe you have found a security issue in OpenBao, please responsibly disclose by contacting us at [openbao-security@lists.lfedge.org](mailto:openbao-security@lists.lfedge.org).
 
 ## CVE history
+
+Fixed OpenBao-related vulnerabilities are described in the specific [release notes](https://openbao.org/docs/release-notes/).

--- a/profile/README.md
+++ b/profile/README.md
@@ -37,6 +37,10 @@ We love ❤ open source and building our project in the open.
 - Join us so we can make OpenBao more robust and more inclusive.
 - Please read our [contribution guidelines](https://github.com/openbao/openbao/blob/main/CONTRIBUTING.md) for details of how you can get involved and [Code of Conduct](https://lfprojects.org/policies/code-of-conduct/) for information about how to participate.
 
+### Security
+
+Please consult our [security policy](../SECURITY.md), if you believe to have identified a security issue or problem.
+
 ### Appendix
 
 - [Documentation Site](https://openbao.org/)


### PR DESCRIPTION
A small PR to ensure users find their way to the security policy more quickly, without having to jump into one of the projects/repositories first.

Also related to our OSPS activities:

* https://github.com/openbao/openbao/pull/1273
* https://github.com/openbao/dev-wg/issues/16