### PR TITLE
Point mailing list references from LF Edge to OpenSSF domain

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a vulnerability
 
-We take OpenBao's security and our users' trust very seriously. If you believe you have found a security issue in OpenBao, please responsibly disclose by contacting us at [openbao-security@lists.lfedge.org](mailto:openbao-security@lists.lfedge.org).
+We take OpenBao's security and our users' trust very seriously. If you believe you have found a security issue in OpenBao, please responsibly disclose by contacting us at [openbao-security@lists.openssf.org](mailto:openbao-security@lists.openssf.org).
 
 ## CVE history
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -19,8 +19,8 @@ For reporting bugs, requesting features, and discussing changes, developers shou
 
 You can reach out to us through the following channels as well:
 
-- [Mailing List](https://lists.lfedge.org/g/openbao)
-- [TSC Mailing List](https://lists.lfedge.org/g/openbao-tsc)
+- [Mailing List](https://lists.openssf.org/g/openbao)
+- [TSC Mailing List](https://lists.openssf.org/g/openbao-tsc)
 - [Chat Server](https://chat.lfx.linuxfoundation.org/)
   - `#openbao-announcements` ([matrix client](https://matrix.to/#/#openbao-announcements:chat.lfx.linuxfoundation.org), [home server](https://chat.lfx.linuxfoundation.org/#/room/#openbao-announcements:chat.lfx.linuxfoundation.org))
   - `#openbao-development` ([matrix client](https://matrix.to/#/#openbao-development:chat.lfx.linuxfoundation.org), [home server](https://chat.lfx.linuxfoundation.org/#/room/#openbao-development:chat.lfx.linuxfoundation.org))


### PR DESCRIPTION
Since the mailing lists have also been migrated from the LF Edge to the OpenSSF, we should also update their references.

Related to https://github.com/openbao/openbao/issues/1413.